### PR TITLE
Add browser platform configuration for plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -59,4 +59,13 @@
             <clobbers target="WindowsAzure" />
         </js-module>
     </platform>
+
+    <platform name="browser">
+        <js-module src="www/MobileServices.Cordova.Ext.js" name="AzureMobileServices.Ext">
+            <runs />
+        </js-module>
+        <js-module src="www/MobileServices.Cordova.js" name="AzureMobileServices">
+            <clobbers target="WindowsAzure" />
+        </js-module>
+    </platform>
 </plugin>


### PR DESCRIPTION
The current plugin.xml doesn't have a section for the platform "browser".  This platform is listed in the package.json for the plugin as a supported platform.  Currently, if you do a `cordova platform add browser`, this plugin will not be added, and when running the browser solution, you will receive errors.  Adding this section to the plugin.xml allows the browser platform to configure this plugin correctly. 