### PR TITLE
Fix incorrect order of params in sqlite INSTR method parser

### DIFF
--- a/www/MobileServices.Cordova.js
+++ b/www/MobileServices.Cordova.js
@@ -3265,9 +3265,9 @@ var SqlFormatter = types.deriveClass(ExpressionVisitor, ctor, {
         else if (functionName == 'indexof') {
             if (this.flavor === 'sqlite') {
                 this.statement.sql += "(INSTR(";
-                this.visit(args[0]);
-                this.statement.sql += ", ";
                 this.visit(instance);
+                this.statement.sql += ", ";
+                this.visit(args[0]);
                 this.statement.sql += ') - 1)';
             } else {
                 this.statement.sql += "(PATINDEX('%' + ";


### PR DESCRIPTION
As documented in https://www.sqlite.org/lang_corefunc.html.
Params order for INSTR is reversed compared to SQL PATINDEX analog.