### PR TITLE
Fix plugin.xml to prevent breaking changes

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -73,7 +73,7 @@
     </platform>
 
     <platform name="android">
-        <framework src="com.microsoft.azure:azure-mobile-android:3.3.0"/>
+        <framework src="com.microsoft.azure:azure-mobile-android:3.3.0@aar"/>
 
         <source-file src="src/android/MobileServices.java"
                      target-dir="src/com/microsoft/windowsazure/mobileservices/cordova" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,24 +57,6 @@
         <source-file src="src/ios/AppDelegate+MobileServicesPlugin.m"/>
 	    <header-file src="src/ios/AppDelegate+MobileServicesPlugin.h"/>
 
-        <!-- appname for deep-link  -->
-        <config-file target="*-Info.plist" parent="AzureMobileAppsRedirectUriScheme">
-            <string>appname</string>
-        </config-file>
-
-        <config-file target="*-Info.plist" parent="CFBundleURLTypes">
-            <array>
-                <dict>
-                    <key>CFBundleURLName</key>
-                    <string>com.microsoft.azure.zumo</string>
-                    <key>CFBundleURLSchemes</key>
-                    <array>
-                        <string>appname</string>
-                    </array>
-                </dict>
-            </array>
-        </config-file>
-
         <config-file target="config.xml" parent="/*">
             <feature name="MobileServices">
                 <param name="ios-package" value="MobileServicesPlugin" />
@@ -101,21 +83,7 @@
                 <param name="android-package" value="com.microsoft.windowsazure.mobileservices.cordova.MobileServices" />
                 <param name="onload" value="true" />
             </feature>
-        </config-file>  
-
-        <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <meta-data android:name=".azure_mobileapps_redirect_uri_scheme" android:value="${redirectUriScheme}" />
-            <activity android:name="com.microsoft.windowsazure.mobileservices.authentication.RedirectUrlActivity">
-                <intent-filter>
-                    <action android:name="android.intent.action.VIEW" />
-                    <category android:name="android.intent.category.DEFAULT" />
-                    <category android:name="android.intent.category.BROWSABLE" />
-                    <data android:host="easyauth.callback" android:scheme="${redirectUriScheme}" />
-                </intent-filter>
-            </activity>
-            <activity android:exported="false" android:name="com.microsoft.windowsazure.mobileservices.authentication.CustomTabsIntermediateActivity" />
-            <activity android:exported="false" android:launchMode="singleTask" android:name="com.microsoft.windowsazure.mobileservices.authentication.CustomTabsLoginActivity" />
-        </config-file> 
+        </config-file>
 
         <js-module src="www/MobileServices.Cordova.Ext.js" name="AzureMobileServices.Ext">
             <runs />

--- a/src/android/MobileServices.java
+++ b/src/android/MobileServices.java
@@ -31,6 +31,10 @@ public class MobileServices extends CordovaPlugin {
 
     public static final int GOOGLE_LOGIN_REQUEST_CODE = 1;
     private static final String MANIFEST_REDIRECT_URI_SCHEME_KEY = ".azure_mobileapps_redirect_uri_scheme";
+    private static final String COULD_NOT_READ_REDIRECT_URI_SCHEME_MSG =
+            "Could not read redirect uri scheme from manifest. " +
+                    "Did you have this line '<meta-data android:name=\".azure_mobileapps_redirect_uri_scheme\" android:value=\"YOUR_URI_SCHEME\" />' " +
+                    "appeared and configured in your AndroidManifest.xml?";
     private MobileServiceClient mobileServiceClient = null;
     private CallbackContext resultContext;
 
@@ -87,6 +91,7 @@ public class MobileServices extends CordovaPlugin {
 
     /**
      * Get redirect uri scheme value from AndroidManifest.xml
+     *
      * @return String
      * @throws Exception
      */
@@ -96,13 +101,13 @@ public class MobileServices extends CordovaPlugin {
         try {
             ai = activity.getPackageManager().getApplicationInfo(activity.getPackageName(), PackageManager.GET_META_DATA);
         } catch (PackageManager.NameNotFoundException e) {
-            String message =
-                    "Could not read redirect uri scheme from manifest. " +
-                            "Did you have this line '<meta-data android:name=\".azure_mobileapps_redirect_uri_scheme\" android:value=\"YOUR_URI_SCHEME\" />' " +
-                            "appeared and configured in your AndroidManifest.xml?";
-            throw new Exception(message);
+            throw new Exception(COULD_NOT_READ_REDIRECT_URI_SCHEME_MSG);
         }
+
         Bundle bundle = ai.metaData;
+        if (bundle == null) {
+            throw new Exception(COULD_NOT_READ_REDIRECT_URI_SCHEME_MSG);
+        }
         String uriScheme = bundle.getString(MANIFEST_REDIRECT_URI_SCHEME_KEY);
         if (uriScheme == null || uriScheme.isEmpty()) {
             String message =
@@ -116,6 +121,7 @@ public class MobileServices extends CordovaPlugin {
 
     /**
      * Convert MobileServiceUser object to javascript 'Token' object to pass it in callback
+     *
      * @param user MobileServiceUser object
      * @return JSONObject
      */


### PR DESCRIPTION
This PR fixes #55 an #60.

Release notes should be added in upcoming version for users who are using google authentication. The following draft can be used:
```
This version fixes issues related with the fact that Google no longer supports InAppBrowser plugin to perform OAuth requests within it. If you are using google authentication for your Cordova application please do the following after update:
% Link for a new documentation section%
```